### PR TITLE
fix build target, adds arm support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,8 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
+# Binaries
+bin/
 
 ### Linux ###
 *~
@@ -45,6 +45,9 @@
 !.vscode/launch.json
 !.vscode/extensions.json
 !.vscode/*.code-snippets
+
+# IntelliJ
+.idea/
 
 # Local History for Visual Studio Code
 .history/

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ ifeq ($(arch1),x86_64)
 arch2=amd64
 else ifeq ($(arch1),aarch64)
 arch2=arm64
+else ifeq ($(arch1),arm64)
+arch2=arm64
 else
 $(error unsupported ARCH: $(arch1))
 endif
@@ -114,7 +116,7 @@ space := $(null)
 .PHONY: build
 
 ## Compile Go binaries for the Galadriel.
-build: bin/spire-bridge-server
+build: bin/galadriel-harvester bin/galadriel-server
 
 # This is the master template for compiling Go binaries
 define binary_rule
@@ -126,7 +128,8 @@ endef
 
 # This dynamically generates targets for each binary using
 # the binary_rule template above
-$(eval $(call binary_rule,bin/spire-bridge-server,./cmd/jwtglue))
+$(eval $(call binary_rule,bin/galadriel-harvester,cmd/harvester/main.go))
+$(eval $(call binary_rule,bin/galadriel-server,cmd/server/main.go))
 
 
 # #

--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,8 @@ endef
 $(eval $(call binary_rule,bin/galadriel-harvester,cmd/harvester/main.go))
 $(eval $(call binary_rule,bin/galadriel-server,cmd/server/main.go))
 
+bin/:
+	@mkdir -p $@
 
 # #
 # # code generation


### PR DESCRIPTION
<!--
1. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->
->make build now generates a binary for galadriel server and harvester.
->removed a restriction in the makefile that wouldn't allow for arm builds.  

**Description of change**
<!-- Please provide a description of the change -->
Regarding support for arm builds, we can build SPIRE for arms so I thought this could be an alternative for developing natively on new macs, as the other ways around (simulation and running externally) are quite sub-optimal. With that said, I'd love to discuss more about this if anyone has thoughts.

Signed-off-by: Juliano Fantozzi <juliano.fantozzi@gmail.com>
