### PR TITLE
Sync federated bundles loop

### DIFF
--- a/cmd/harvester/cli/run.go
+++ b/cmd/harvester/cli/run.go
@@ -3,11 +3,12 @@ package cli
 import (
 	"context"
 	"fmt"
-	"github.com/HewlettPackard/galadriel/pkg/harvester"
-	"github.com/spf13/cobra"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/HewlettPackard/galadriel/pkg/harvester"
+	"github.com/spf13/cobra"
 )
 
 const defaultConfigPath = "conf/harvester/harvester.conf"
@@ -18,7 +19,6 @@ func NewRunCmd() *cobra.Command {
 		Short: "Runs the Galadriel Harvester",
 		Long:  "Run this command to start the Galadriel Harvester",
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			config, err := LoadConfig(cmd)
 			if err != nil {
 				return err

--- a/pkg/common/api.go
+++ b/pkg/common/api.go
@@ -10,9 +10,13 @@ type BundleUpdates map[spiffeid.TrustDomain]TrustBundle
 
 // TrustBundle represents a SPIFFE Trust bundle along with its digest.
 type TrustBundle struct {
-	TrustDomain  spiffeid.TrustDomain `json:"trust_domain"`
-	Bundle       []byte               `json:"trust_bundle"`
-	BundleDigest []byte               `json:"bundle_digest"`
+	// Trust Domain of the bundle
+	TrustDomain spiffeid.TrustDomain `json:"trust_domain"`
+	// SPIFFE bundle according to the SPIFFE Trust Domain and Bundle specification.
+	// https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Trust_Domain_and_Bundle.md#4-spiffe-bundle-format
+	Bundle []byte `json:"trust_bundle"`
+	// SHA3-256 digest of the PEM-encoded X.509 bundle certificate blocks.
+	BundleDigest []byte `json:"bundle_digest"`
 }
 
 // SyncBundleRequest represents a request to send the current state of federated bundles digests.

--- a/pkg/common/util/task.go
+++ b/pkg/common/util/task.go
@@ -7,9 +7,11 @@ import (
 	"sync"
 )
 
+type RunnableTask func(context.Context) error
+
 // RunTasks runs all the given tasks concurrently and waits for all of them to be completed.
 // If one task is canceled, all the other tasks are canceled.
-func RunTasks(ctx context.Context, tasks []func(context.Context) error) error {
+func RunTasks(ctx context.Context, tasks ...RunnableTask) error {
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(ctx)
 	defer func() {
@@ -19,7 +21,7 @@ func RunTasks(ctx context.Context, tasks []func(context.Context) error) error {
 
 	errch := make(chan error, len(tasks))
 
-	runTask := func(task func(context.Context) error) (err error) {
+	runTask := func(task RunnableTask) (err error) {
 		defer func() {
 			if r := recover(); r != nil {
 				err = fmt.Errorf("panic: %v\n%s\n", r, string(debug.Stack())) //nolint: revive // newlines are intentional

--- a/pkg/harvester/client/server.go
+++ b/pkg/harvester/client/server.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,13 +16,14 @@ import (
 const (
 	contentType = "application/json"
 
-	postBundlePath = "/bundle"
-	onboardPath    = "/onboard"
+	postBundlePath     = "/bundle"
+	postBundleSyncPath = "/bundle/sync"
+	onboardPath        = "/onboard"
 )
 
 // GaladrielServerClient represents a client to connect to Galadriel Server
 type GaladrielServerClient interface {
-	GetUpdates(context.Context) ([]string, error)
+	SyncFederatedBundles(context.Context, *common.SyncBundleRequest) (*common.SyncBundleResponse, error)
 	PostBundle(context.Context, *common.PostBundleRequest) error
 	Connect(ctx context.Context, token string) error
 }
@@ -70,37 +70,64 @@ func (c *client) Connect(ctx context.Context, token string) error {
 	return nil
 }
 
-func readBody(resp *http.Response) (string, error) {
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-	bodyString := string(bodyBytes)
-	return bodyString, nil
-}
-
-func (c *client) GetUpdates(ctx context.Context) ([]string, error) {
-	return nil, errors.New("not implemented")
-}
-
-func (s *client) PostBundle(ctx context.Context, req *common.PostBundleRequest) error {
+func (c *client) SyncFederatedBundles(ctx context.Context, req *common.SyncBundleRequest) (*common.SyncBundleResponse, error) {
 	b, err := json.Marshal(req)
 	if err != nil {
-		s.logger.Debug("Pushing Bundle: \n" + string(b))
+		return nil, fmt.Errorf("failed to marshal federated bundle request: %v", err)
+	}
+
+	c.logger.Debugf("Sending post federated bundles updates:\n%s", b)
+	url := c.address + postBundleSyncPath
+	r, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(b))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %v", err)
+	}
+
+	// TODO: decorate all requests coming out
+	r.Header.Set("Authorization", "Bearer "+c.token)
+	r.Header.Set("Content-Type", contentType)
+
+	res, err := c.c.Do(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %v", err)
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %v", err)
+	}
+
+	// TODO: check right status code
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("request returned an error code %d: \n%s", res.StatusCode, body)
+	}
+
+	var syncBundleResponse common.SyncBundleResponse
+	if err := json.Unmarshal(body, &syncBundleResponse); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal sync bundle response: %v", err)
+	}
+
+	return &syncBundleResponse, nil
+}
+
+func (c *client) PostBundle(ctx context.Context, req *common.PostBundleRequest) error {
+	b, err := json.Marshal(req)
+	if err != nil {
 		return fmt.Errorf("failed to marshal push bundle request: %v", err)
 	}
 
-	url := s.address + postBundlePath
+	url := c.address + postBundlePath
 	r, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(b))
 	if err != nil {
 		return fmt.Errorf("failed to create push bundle request: %v", err)
 	}
 
 	// TODO: decorate all requests coming out
-	r.Header.Set("Authorization", "Bearer "+s.token)
+	r.Header.Set("Authorization", "Bearer "+c.token)
 	r.Header.Set("Content-Type", contentType)
 
-	res, err := s.c.Do(r)
+	res, err := c.c.Do(r)
 	if err != nil {
 		return fmt.Errorf("failed to send push bundle request: %v", err)
 	}
@@ -117,4 +144,13 @@ func (s *client) PostBundle(ctx context.Context, req *common.PostBundleRequest) 
 	}
 
 	return nil
+}
+
+func readBody(resp *http.Response) (string, error) {
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	bodyString := string(bodyBytes)
+	return bodyString, nil
 }

--- a/pkg/harvester/controller/watcher/bundle.go
+++ b/pkg/harvester/controller/watcher/bundle.go
@@ -1,0 +1,185 @@
+package watcher
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/HewlettPackard/galadriel/pkg/common"
+	"github.com/HewlettPackard/galadriel/pkg/common/telemetry"
+	"github.com/HewlettPackard/galadriel/pkg/common/util"
+	"github.com/HewlettPackard/galadriel/pkg/harvester/client"
+	"github.com/HewlettPackard/galadriel/pkg/harvester/spire"
+	"github.com/sirupsen/logrus"
+	"github.com/spiffe/go-spiffe/v2/bundle/spiffebundle"
+)
+
+var logger = logrus.WithField(telemetry.SubsystemName, telemetry.HarvesterController)
+
+func BuildSelfBundleWatcher(interval time.Duration, server client.GaladrielServerClient, spire spire.SpireServer) util.RunnableTask {
+	return func(ctx context.Context) error {
+		t := time.NewTicker(interval)
+		var currentDigest []byte
+
+		for {
+			select {
+			case <-t.C:
+				bundle, digest, hasNew := hasNewBundle(ctx, currentDigest, spire)
+				if !hasNew {
+					break
+				}
+				logger.Info("Bundle has changed, pushing to Galadriel Server")
+
+				req, err := buildPostBundleRequest(bundle)
+				if err != nil {
+					logger.Error(err)
+					break
+				}
+
+				if err = server.PostBundle(ctx, req); err != nil {
+					logger.Errorf("Failed to push X.509 bundle: %v", err)
+					break
+				}
+				logger.Debug("New bundle successfully pushed to Galadriel Server")
+
+				currentDigest = digest
+			case <-ctx.Done():
+				return nil
+			}
+		}
+	}
+}
+
+func BuildFederatedBundlesWatcher(interval time.Duration, server client.GaladrielServerClient, spire spire.SpireServer) util.RunnableTask {
+	return func(ctx context.Context) error {
+		t := time.NewTicker(interval)
+
+		for {
+			select {
+			case <-t.C:
+				req, err := buildSyncBundlesRequest(ctx, spire)
+				if err != nil {
+					logger.Errorf("Failed to build sync federated bundle request: %v", err)
+					break
+				}
+
+				res, err := server.SyncFederatedBundles(ctx, req)
+				if err != nil {
+					logger.Errorf("Failed to get federated bundles updates: %v", err)
+					break
+				}
+
+				bundles, processed := federatedBundlesUpdatesToSpiffeBundles(res)
+				updatesLen := uint32(len(res.Updates))
+				if updatesLen != processed {
+					logger.Errorf("Failed to process %d out of %d trust domains", updatesLen-processed, updatesLen)
+				}
+
+				if len(bundles) == 0 {
+					logger.Debug("No new federated bundles to set")
+					break
+				}
+
+				logger.Infof("Setting %d new federated bundle(s)", len(bundles))
+				if _, err = spire.SetFederatedBundles(ctx, bundles); err != nil {
+					logger.Errorf("%v", err)
+				}
+			case <-ctx.Done():
+				return nil
+			}
+		}
+	}
+}
+
+func hasNewBundle(ctx context.Context, currentDigest []byte, spire spire.SpireServer) (newBundle *spiffebundle.Bundle, newDigest []byte, hasNew bool) {
+	spireBundle, err := spire.GetBundle(ctx)
+	if err != nil {
+		logger.Errorf("Failed to get spire bundle: %v", err)
+		return nil, nil, false
+	}
+
+	b, err := spireBundle.X509Bundle().Marshal()
+	if err != nil {
+		logger.Errorf("Failed to marshal spire X.509 bundle: %v", err)
+		return nil, nil, false
+	}
+	spireDigest := util.GetDigest(b)
+
+	if !bytes.Equal(currentDigest, spireDigest) {
+		return spireBundle, spireDigest, true
+	}
+
+	return nil, nil, false
+}
+
+func buildPostBundleRequest(b *spiffebundle.Bundle) (*common.PostBundleRequest, error) {
+	bundle, err := b.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal X.509 bundle: %v", err)
+	}
+
+	x509b, err := b.X509Bundle().Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal X.509 bundle: %v", err)
+	}
+
+	req := &common.PostBundleRequest{
+		TrustBundle: common.TrustBundle{
+			TrustDomain:  b.TrustDomain(),
+			Bundle:       bundle,
+			BundleDigest: util.GetDigest(x509b),
+		},
+	}
+
+	return req, nil
+}
+
+func buildSyncBundlesRequest(ctx context.Context, spire spire.SpireServer) (*common.SyncBundleRequest, error) {
+	res, err := spire.GetFederatedBundles(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	digests := make(common.BundlesDigests)
+
+	for _, b := range res.Bundles {
+		td := b.TrustDomain()
+		if err != nil {
+			logger.Errorf("Failed to marshal bundle for trust domain %s: %v", td, err)
+			continue
+		}
+
+		x509b, err := b.X509Bundle().Marshal()
+		if err != nil {
+			logger.Errorf("Failed to marshal X.509 bundle for trust domain %s: %v", td, err)
+			continue
+		}
+
+		digests[td] = util.GetDigest(x509b)
+	}
+
+	state := &common.SyncBundleRequest{State: digests}
+
+	return state, nil
+}
+
+func federatedBundlesUpdatesToSpiffeBundles(res *common.SyncBundleResponse) (bundles []*spiffebundle.Bundle, processed uint32) {
+	for td, b := range res.Updates {
+		if b.Bundle == nil {
+			logger.Errorf("Received an empty bundle for trust domain %q", td)
+			continue
+		}
+
+		bundle, err := spiffebundle.Parse(td, b.Bundle)
+		if err != nil {
+			logger.Errorf("Failed to parse trust bundle for %q: %v", td, err)
+			continue
+		}
+
+		bundles = append(bundles, bundle)
+		processed++
+	}
+
+	return bundles, processed
+}

--- a/pkg/harvester/harvester.go
+++ b/pkg/harvester/harvester.go
@@ -54,11 +54,7 @@ func (h *Harvester) Run(ctx context.Context) error {
 		return err
 	}
 
-	tasks := []func(context.Context) error{
-		c.Run,
-	}
-
-	err = util.RunTasks(ctx, tasks)
+	err = util.RunTasks(ctx, c.Run)
 	if errors.Is(err, context.Canceled) {
 		err = nil
 	}

--- a/pkg/harvester/spire/client_fake_test.go
+++ b/pkg/harvester/spire/client_fake_test.go
@@ -84,3 +84,11 @@ func (c fakeInternalClient) GetBundle(context.Context) (*spiffebundle.Bundle, er
 func (c fakeInternalClient) BatchSetFederatedBundle(context.Context, []*spiffebundle.Bundle) ([]*BatchSetFederatedBundleStatus, error) {
 	return nil, errors.New("not implemented")
 }
+
+func (c fakeInternalClient) ListFederatedBundles(context.Context) (*ListFederatedBundlesResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c fakeInternalClient) GetFederatedBundles(context.Context, []*spiffebundle.Bundle) ([]*BatchSetFederatedBundleStatus, error) {
+	return nil, errors.New("not implemented")
+}

--- a/pkg/harvester/spire/proto.go
+++ b/pkg/harvester/spire/proto.go
@@ -174,7 +174,6 @@ func protoToBatchSetFederatedBundleResult(in *bundlev1.BatchSetFederatedBundleRe
 			if err != nil {
 				return nil, err
 			}
-
 		}
 
 		if r.Status == nil {
@@ -189,6 +188,21 @@ func protoToBatchSetFederatedBundleResult(in *bundlev1.BatchSetFederatedBundleRe
 			},
 		}
 		out = append(out, bs)
+	}
+
+	return out, nil
+}
+
+func protoToFederatedBundles(in *bundlev1.ListFederatedBundlesResponse) ([]*spiffebundle.Bundle, error) {
+	var out []*spiffebundle.Bundle
+
+	for _, b := range in.Bundles {
+		bundle, err := protoToBundle(b)
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, bundle)
 	}
 
 	return out, nil

--- a/pkg/harvester/spire/spire.go
+++ b/pkg/harvester/spire/spire.go
@@ -17,6 +17,7 @@ import (
 type SpireServer interface {
 	GetBundle(context.Context) (*spiffebundle.Bundle, error)
 	SetFederatedBundles(context.Context, []*spiffebundle.Bundle) ([]*BatchSetFederatedBundleStatus, error)
+	GetFederatedBundles(context.Context) (*ListFederatedBundlesResponse, error)
 }
 
 type localSpireServer struct {
@@ -55,7 +56,17 @@ func (s *localSpireServer) GetBundle(ctx context.Context) (*spiffebundle.Bundle,
 	return bundle, nil
 }
 
-// SetFederatedBundles adds or updates a set of federated bundles on a SPIRE Server
+// GetFederatedBundles lists all the external SPIFFE bundles the SPIRE Server knows about
+func (s *localSpireServer) GetFederatedBundles(ctx context.Context) (*ListFederatedBundlesResponse, error) {
+	bundles, err := s.client.ListFederatedBundles(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return bundles, nil
+}
+
+// SetFederatedBundles adds or updates a set of federated SPIFFE bundles on the SPIRE Server
 func (s *localSpireServer) SetFederatedBundles(ctx context.Context, bundles []*spiffebundle.Bundle) ([]*BatchSetFederatedBundleStatus, error) {
 	res, err := s.client.BatchSetFederatedBundle(ctx, bundles)
 	if err != nil {

--- a/pkg/harvester/spire/types.go
+++ b/pkg/harvester/spire/types.go
@@ -15,3 +15,11 @@ type BatchSetFederatedBundleStatus struct {
 	Bundle *spiffebundle.Bundle
 	Status *Status
 }
+
+type BatchGetFederatedBundleStatus struct {
+	Bundle *spiffebundle.Bundle
+}
+
+type ListFederatedBundlesResponse struct {
+	Bundles []*spiffebundle.Bundle
+}

--- a/pkg/server/endpoints/run.go
+++ b/pkg/server/endpoints/run.go
@@ -40,12 +40,10 @@ func New(c *Config) (*Endpoints, error) {
 }
 
 func (e *Endpoints) ListenAndServe(ctx context.Context) error {
-	tasks := []func(context.Context) error{
+	err := util.RunTasks(ctx,
 		e.runTCPServer,
 		e.runUDSServer,
-	}
-
-	err := util.RunTasks(ctx, tasks)
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+
 	"github.com/HewlettPackard/galadriel/pkg/common/telemetry"
 	"github.com/HewlettPackard/galadriel/pkg/common/util"
 	"github.com/HewlettPackard/galadriel/pkg/server/catalog"
@@ -39,11 +40,7 @@ func (s *Server) run(ctx context.Context) (err error) {
 		return err
 	}
 
-	tasks := []func(context.Context) error{
-		endpointsServer.ListenAndServe,
-	}
-
-	err = util.RunTasks(ctx, tasks)
+	err = util.RunTasks(ctx, endpointsServer.ListenAndServe)
 	if errors.Is(err, context.Canceled) {
 		err = nil
 	}


### PR DESCRIPTION
<!--
1. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**

**Description of change**
Adds a loop in the Harvester that periodically asks for bundle updates to the Galadriel Server. If the Server responds with new bundles, the Harvester sets them in the SPIRE Server.
In order to save some bytes over the wire, the Harvester hashes the federated bundles from the SPIRE Server, and sends that to the Galadriel Server. Then the Galadriel Server receives these hashes and compares them with the hashed bundles it has (the Galadriel Server side will be implemented by #58).

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

