### PR TITLE
Updates trivy action runner

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   build:
     name: Build
-    runs-on: "ubuntu-18.04"
+    runs-on: ubuntu-latest
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results


### PR DESCRIPTION
**Pull request check list**

- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
The trivy action in our Github Actions pipeline will work again.

**Description of change**
Our PRs are now stuck in a pending state trying to find a runner for the `trivy` action:
```
Requested labels: ubuntu-18.04
Job defined at: HewlettPackard/galadriel/.github/workflows/trivy.yml@refs/pull/131/merge
Waiting for a runner to pick up this job...
```
The runner `ubuntu-18.04` was [decommissioned](https://github.com/actions/runner-images/issues/6002) a few days ago.

This PR updates the action to the latest runner.

**Which issue this pull requests fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this pull request is merged -->

