### PR TITLE
Add Release Workflow and Build Script for Automated Releases

### DIFF
--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -22,6 +22,12 @@ jobs:
       - name: Check out code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
+      - name: Cache Go modules
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
       - name: Get dependencies
         run: go mod download
 

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -8,7 +8,7 @@ env:
 
 permissions:
   contents: write
-  packages: write
+  actions: read
 
 jobs:
   build:

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -22,12 +22,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
-      - name: Cache Go modules
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-
       - name: Get dependencies
         run: go mod download
 
@@ -52,9 +46,6 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Check out code
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-
       - name: Download Artifacts
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -31,6 +31,14 @@ jobs:
       - name: Build Artifacts
         run: ./.github/workflows/scripts/build_artifacts.sh
 
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce   # v3.1.2
+        with:
+          name: release-artifacts
+          path: |
+            galadriel-*-linux-*-glibc.tar.gz
+            galadriel-*-linux-*-glibc.tar.gz.sha256sum.txt
+
   release:
     name: Release
     needs: build
@@ -39,10 +47,15 @@ jobs:
       contents: write
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: release-artifacts
 
       - name: Release
-        uses: softprops/action-gh-release@v26994186c0ac3ef5cae75ac16aa32e8153525f77  # v1
+        uses: softprops/action-gh-release@26994186c0ac3ef5cae75ac16aa32e8153525f77  # v1
         with:
           files: |
             galadriel-*-linux-*-glibc.tar.gz

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -14,13 +14,13 @@ jobs:
       contents: read
       actions: read
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v2
+      - name: Setup go
+        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
       - name: Get dependencies
         run: go mod download
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v26994186c0ac3ef5cae75ac16aa32e8153525f77  # v1
         with:
           files: |
             galadriel-*-linux-*-glibc.tar.gz

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -6,23 +6,21 @@ on:
 env:
   GO_VERSION: 1.20.3
 
-permissions:
-  contents: write
-  actions: read
-
 jobs:
   build:
-    name: Build and Release
+    name: Build Artifacts
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      actions: read
     steps:
-      - name: Setup go
-        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+      - name: Set up Go
+        uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - name: Check out code
+        uses: actions/checkout@v2
 
       - name: Get dependencies
         run: go mod download
@@ -33,8 +31,18 @@ jobs:
       - name: Build Artifacts
         run: ./.github/workflows/scripts/build_artifacts.sh
 
+  release:
+    name: Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
       - name: Release
-        uses: softprops/action-gh-release@26994186c0ac3ef5cae75ac16aa32e8153525f77
+        uses: softprops/action-gh-release@v1
         with:
           files: |
             galadriel-*-linux-*-glibc.tar.gz

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -1,0 +1,39 @@
+name: Release Build
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+' # Trigger this workflow when a new vX.Y.Z tag is pushed
+env:
+  GO_VERSION: 1.20.3
+
+jobs:
+  build:
+    name: Build and Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Get dependencies
+        run: go mod download
+
+      - name: Test
+        run: go test -v ./...
+
+      - name: Build Artifacts
+        run: ./.github/workflows/scripts/build_artifacts.sh
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            galadriel-*-linux-*-glibc.tar.gz
+            galadriel-*-linux-*-glibc.tar.gz.sha256sum.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v2
+      - name: Setup go
+        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Check out code
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
       - name: Get dependencies
         run: go mod download

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -6,6 +6,10 @@ on:
 env:
   GO_VERSION: 1.20.3
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   build:
     name: Build and Release

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -30,7 +30,7 @@ jobs:
         run: ./.github/workflows/scripts/build_artifacts.sh
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@26994186c0ac3ef5cae75ac16aa32e8153525f77
         with:
           files: |
             galadriel-*-linux-*-glibc.tar.gz

--- a/.github/workflows/scripts/build_artifacts.sh
+++ b/.github/workflows/scripts/build_artifacts.sh
@@ -16,9 +16,7 @@ fi
 
 for architecture in "${supported_architectures[@]}"; do
   # Build the server and harvester binaries for the current architecture
-  if GOARCH=$architecture go build -o bin/galadriel-server ./cmd/server && \
-     GOARCH=$architecture go build -o bin/galadriel-harvester ./cmd/harvester; then
-
+  if GOARCH=$architecture make build; then
     echo "Artifacts successfully built for architecture: ${architecture}"
     tarball="galadriel-${version_tag}-linux-${architecture}-glibc.tar.gz"
 

--- a/.github/workflows/scripts/build_artifacts.sh
+++ b/.github/workflows/scripts/build_artifacts.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Builds Galadriel artifacts for Linux for all supported architectures.
+# Usage: build_artifacts.sh
+
+set -e
+
+supported_architectures=(amd64 arm64)
+
+export version_tag=
+if [[ "$GITHUB_REF" =~ ^refs/tags/v[0-9.]+$ ]]; then
+  # Strip off the leading "v" from the release tag. Release artifacts are
+  # named just with the version number (e.g. v0.9.3 tag produces
+  # galadriel-0.9.3-linux-x64.tar.gz).
+  version_tag="${GITHUB_REF##refs/tags/v}"
+fi
+
+for architecture in "${supported_architectures[@]}"; do
+  # Build the server and harvester binaries for the current architecture
+  if GOARCH=$architecture go build -o bin/galadriel-server ./cmd/server && \
+     GOARCH=$architecture go build -o bin/galadriel-harvester ./cmd/harvester; then
+
+    echo "Artifacts successfully built for architecture: ${architecture}"
+    tarball="galadriel-${version_tag}-linux-${architecture}-glibc.tar.gz"
+
+    # Create a tarball with the binaries, license, and conf files
+    tar -czvf "$tarball" -C bin/ . -C ../ LICENSE conf/
+
+    # Generate a SHA-256 checksum for the tarball
+    sha256sum "$tarball" > "$tarball.sha256sum.txt"
+  else
+    echo "Error encountered while building artifact for architecture: ${architecture}"
+    exit 1
+  fi
+done
+
+echo "Build completed successfully for all architectures"


### PR DESCRIPTION
<!--
1. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull request check list**

- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

**Description of change**

This pull request introduces two new files that automate the release process for the Galadriel project. These additions will streamline the creation and publishing of new releases, ensuring that they are consistent, reliable, and require minimal manual intervention.

- GitHub Release Workflow `release_build.yaml`: This GitHub Actions workflow is triggered whenever a new version tag (formatted as `vX.Y.Z`) is pushed to the repository. The workflow sets up the Go environment, checks out the code, downloads dependencies, runs tests, and builds the project's artifacts using the provided build script. It then creates a new GitHub release and uploads the built artifacts and their SHA-256 checksums to it. The workflow is designed to run on an Ubuntu-latest environment.

- Build Artifacts Script `build_artifacts.sh`: This bash script is responsible for building the Galadriel project's artifacts. It supports building for two architectures: `amd64` and `arm64`. For each architecture, it builds the `galadriel-server` and `galadriel-harvester` binaries, packages them along with the `LICENSE` and configuration files into a tarball, and generates a SHA-256 checksum for the tarball. The script is designed to halt on the first error encountered to prevent the propagation of build errors.


**Which issue this pull requests fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this pull request is merged -->

