### PR TITLE
Fix issue with server `socket_path`

### DIFF
--- a/cmd/server/cli/run.go
+++ b/cmd/server/cli/run.go
@@ -89,5 +89,8 @@ func init() {
 	runCmd := NewRunCmd()
 	runCmd.Flags().StringP(cli.ConfigFlagName, "c", defaultConfigPath, "Path to the Galadriel Server config file")
 
+	// Override the socket path flag in the run command to remove the default value. This flag takes precedence over the config file when set.
+	runCmd.PersistentFlags().StringP(cli.SocketPathFlagName, "", "", "Specify the path to the Galadriel Server API socket")
+
 	RootCmd.AddCommand(runCmd)
 }


### PR DESCRIPTION
<!--
1. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull request check list**

- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**

Previously, the `galadriel-server run` command did not utilize the `socket_path` property from the config file due to the `socketPath` flag taking precedence over the config file, even with a default value set.

The issue has been resolved by removing the default value for the `socketPath` flag in the run command. As a result, the `galadriel-server` now correctly utilizes the `socket_path` property when executing the run command.

**Description of change**
<!-- Please provide a description of the change -->

**Which issue this pull requests fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this pull request is merged -->

