### PR TITLE
Allow the customer to optionally set the `created_at` field . Improve datastore tests.

### DIFF
--- a/pkg/server/db/postgres/bundles.sql.go
+++ b/pkg/server/db/postgres/bundles.sql.go
@@ -7,13 +7,14 @@ package postgres
 
 import (
 	"context"
+	"time"
 
 	"github.com/jackc/pgtype"
 )
 
 const createBundle = `-- name: CreateBundle :one
-INSERT INTO bundles(data, digest, signature, signing_certificate, trust_domain_id)
-VALUES ($1, $2, $3, $4, $5)
+INSERT INTO bundles(data, digest, signature, signing_certificate, trust_domain_id, created_at)
+VALUES ($1, $2, $3, $4, $5, $6)
 RETURNING id, trust_domain_id, data, digest, signature, signing_certificate, created_at, updated_at
 `
 
@@ -23,6 +24,7 @@ type CreateBundleParams struct {
 	Signature          []byte
 	SigningCertificate []byte
 	TrustDomainID      pgtype.UUID
+	CreatedAt          time.Time
 }
 
 func (q *Queries) CreateBundle(ctx context.Context, arg CreateBundleParams) (Bundle, error) {
@@ -32,6 +34,7 @@ func (q *Queries) CreateBundle(ctx context.Context, arg CreateBundleParams) (Bun
 		arg.Signature,
 		arg.SigningCertificate,
 		arg.TrustDomainID,
+		arg.CreatedAt,
 	)
 	var i Bundle
 	err := row.Scan(

--- a/pkg/server/db/postgres/datastore.go
+++ b/pkg/server/db/postgres/datastore.go
@@ -473,7 +473,8 @@ func (d *Datastore) DeleteRelationship(ctx context.Context, relationshipID uuid.
 
 func (d *Datastore) createTrustDomain(ctx context.Context, req *entity.TrustDomain) (*TrustDomain, error) {
 	params := CreateTrustDomainParams{
-		Name: req.Name.String(),
+		Name:      req.Name.String(),
+		CreatedAt: req.CreatedAt,
 	}
 	if req.Description != "" {
 		params.Description = sql.NullString{
@@ -524,6 +525,7 @@ func (d *Datastore) createBundle(ctx context.Context, req *entity.Bundle) (*Bund
 		Signature:          req.Signature,
 		SigningCertificate: req.SigningCertificate,
 		TrustDomainID:      pgTrustDomainID,
+		CreatedAt:          req.CreatedAt,
 	}
 
 	bundle, err := d.querier.CreateBundle(ctx, params)
@@ -585,7 +587,6 @@ func (d *Datastore) createRelationship(ctx context.Context, req *entity.Relation
 		TrustDomainAConsent: ConsentStatus(req.TrustDomainAConsent),
 		TrustDomainBConsent: ConsentStatus(req.TrustDomainBConsent),
 		CreatedAt:           req.CreatedAt,
-		UpdatedAt:           req.UpdatedAt,
 	}
 
 	relationship, err := d.querier.CreateRelationship(ctx, params)

--- a/pkg/server/db/postgres/join_tokens.sql.go
+++ b/pkg/server/db/postgres/join_tokens.sql.go
@@ -13,8 +13,8 @@ import (
 )
 
 const createJoinToken = `-- name: CreateJoinToken :one
-INSERT INTO join_tokens(token, expires_at, trust_domain_id)
-VALUES ($1, $2, $3)
+INSERT INTO join_tokens(token, expires_at, trust_domain_id, created_at)
+VALUES ($1, $2, $3, $4)
 RETURNING id, trust_domain_id, token, used, expires_at, created_at, updated_at
 `
 
@@ -22,10 +22,16 @@ type CreateJoinTokenParams struct {
 	Token         string
 	ExpiresAt     time.Time
 	TrustDomainID pgtype.UUID
+	CreatedAt     time.Time
 }
 
 func (q *Queries) CreateJoinToken(ctx context.Context, arg CreateJoinTokenParams) (JoinToken, error) {
-	row := q.queryRow(ctx, q.createJoinTokenStmt, createJoinToken, arg.Token, arg.ExpiresAt, arg.TrustDomainID)
+	row := q.queryRow(ctx, q.createJoinTokenStmt, createJoinToken,
+		arg.Token,
+		arg.ExpiresAt,
+		arg.TrustDomainID,
+		arg.CreatedAt,
+	)
 	var i JoinToken
 	err := row.Scan(
 		&i.ID,

--- a/pkg/server/db/postgres/queries/bundles.sql
+++ b/pkg/server/db/postgres/queries/bundles.sql
@@ -1,6 +1,6 @@
 -- name: CreateBundle :one
-INSERT INTO bundles(data, digest, signature, signing_certificate, trust_domain_id)
-VALUES ($1, $2, $3, $4, $5)
+INSERT INTO bundles(data, digest, signature, signing_certificate, trust_domain_id, created_at)
+VALUES ($1, $2, $3, $4, $5, $6)
 RETURNING *;
 
 -- name: UpdateBundle :one

--- a/pkg/server/db/postgres/queries/join_tokens.sql
+++ b/pkg/server/db/postgres/queries/join_tokens.sql
@@ -1,6 +1,6 @@
 -- name: CreateJoinToken :one
-INSERT INTO join_tokens(token, expires_at, trust_domain_id)
-VALUES ($1, $2, $3)
+INSERT INTO join_tokens(token, expires_at, trust_domain_id, created_at)
+VALUES ($1, $2, $3, $4)
 RETURNING *;
 
 -- name: UpdateJoinToken :one

--- a/pkg/server/db/postgres/queries/relationships.sql
+++ b/pkg/server/db/postgres/queries/relationships.sql
@@ -1,6 +1,6 @@
 -- name: CreateRelationship :one
-INSERT INTO relationships(trust_domain_a_id, trust_domain_b_id, trust_domain_a_consent, trust_domain_b_consent, created_at, updated_at)
-VALUES ($1, $2, $3, $4, $5, $6)
+INSERT INTO relationships(trust_domain_a_id, trust_domain_b_id, trust_domain_a_consent, trust_domain_b_consent, created_at)
+VALUES ($1, $2, $3, $4, $5)
 RETURNING *;
 
 -- name: UpdateRelationship :one

--- a/pkg/server/db/postgres/queries/trust_domains.sql
+++ b/pkg/server/db/postgres/queries/trust_domains.sql
@@ -1,6 +1,6 @@
 -- name: CreateTrustDomain :one
-INSERT INTO trust_domains(name, description)
-VALUES ($1, $2)
+INSERT INTO trust_domains(name, description, created_at)
+VALUES ($1, $2, $3)
 RETURNING *;
 
 -- name: UpdateTrustDomain :one

--- a/pkg/server/db/postgres/relationships.sql.go
+++ b/pkg/server/db/postgres/relationships.sql.go
@@ -13,8 +13,8 @@ import (
 )
 
 const createRelationship = `-- name: CreateRelationship :one
-INSERT INTO relationships(trust_domain_a_id, trust_domain_b_id, trust_domain_a_consent, trust_domain_b_consent, created_at, updated_at)
-VALUES ($1, $2, $3, $4, $5, $6)
+INSERT INTO relationships(trust_domain_a_id, trust_domain_b_id, trust_domain_a_consent, trust_domain_b_consent, created_at)
+VALUES ($1, $2, $3, $4, $5)
 RETURNING id, trust_domain_a_id, trust_domain_b_id, trust_domain_a_consent, trust_domain_b_consent, created_at, updated_at
 `
 
@@ -24,7 +24,6 @@ type CreateRelationshipParams struct {
 	TrustDomainAConsent ConsentStatus
 	TrustDomainBConsent ConsentStatus
 	CreatedAt           time.Time
-	UpdatedAt           time.Time
 }
 
 func (q *Queries) CreateRelationship(ctx context.Context, arg CreateRelationshipParams) (Relationship, error) {
@@ -34,7 +33,6 @@ func (q *Queries) CreateRelationship(ctx context.Context, arg CreateRelationship
 		arg.TrustDomainAConsent,
 		arg.TrustDomainBConsent,
 		arg.CreatedAt,
-		arg.UpdatedAt,
 	)
 	var i Relationship
 	err := row.Scan(

--- a/pkg/server/db/postgres/trust_domains.sql.go
+++ b/pkg/server/db/postgres/trust_domains.sql.go
@@ -8,23 +8,25 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"time"
 
 	"github.com/jackc/pgtype"
 )
 
 const createTrustDomain = `-- name: CreateTrustDomain :one
-INSERT INTO trust_domains(name, description)
-VALUES ($1, $2)
+INSERT INTO trust_domains(name, description, created_at)
+VALUES ($1, $2, $3)
 RETURNING id, name, description, created_at, updated_at
 `
 
 type CreateTrustDomainParams struct {
 	Name        string
 	Description sql.NullString
+	CreatedAt   time.Time
 }
 
 func (q *Queries) CreateTrustDomain(ctx context.Context, arg CreateTrustDomainParams) (TrustDomain, error) {
-	row := q.queryRow(ctx, q.createTrustDomainStmt, createTrustDomain, arg.Name, arg.Description)
+	row := q.queryRow(ctx, q.createTrustDomainStmt, createTrustDomain, arg.Name, arg.Description, arg.CreatedAt)
 	var i TrustDomain
 	err := row.Scan(
 		&i.ID,

--- a/pkg/server/db/sqlite/bundles.sql.go
+++ b/pkg/server/db/sqlite/bundles.sql.go
@@ -7,11 +7,12 @@ package sqlite
 
 import (
 	"context"
+	"time"
 )
 
 const createBundle = `-- name: CreateBundle :one
-INSERT INTO bundles(id, data, digest, signature, signing_certificate, trust_domain_id)
-VALUES (?, ?, ?, ?, ?, ?)
+INSERT INTO bundles(id, data, digest, signature, signing_certificate, trust_domain_id, created_at)
+VALUES (?, ?, ?, ?, ?, ?, ?)
 RETURNING id, trust_domain_id, data, digest, signature, signing_certificate, created_at, updated_at
 `
 
@@ -22,6 +23,7 @@ type CreateBundleParams struct {
 	Signature          []byte
 	SigningCertificate []byte
 	TrustDomainID      string
+	CreatedAt          time.Time
 }
 
 func (q *Queries) CreateBundle(ctx context.Context, arg CreateBundleParams) (Bundle, error) {
@@ -32,6 +34,7 @@ func (q *Queries) CreateBundle(ctx context.Context, arg CreateBundleParams) (Bun
 		arg.Signature,
 		arg.SigningCertificate,
 		arg.TrustDomainID,
+		arg.CreatedAt,
 	)
 	var i Bundle
 	err := row.Scan(

--- a/pkg/server/db/sqlite/datastore.go
+++ b/pkg/server/db/sqlite/datastore.go
@@ -228,6 +228,7 @@ func (d *Datastore) CreateJoinToken(ctx context.Context, req *entity.JoinToken) 
 		Token:         req.Token,
 		ExpiresAt:     req.ExpiresAt,
 		TrustDomainID: req.TrustDomainID.String(),
+		CreatedAt:     req.CreatedAt,
 	}
 	joinToken, err := d.querier.CreateJoinToken(ctx, params)
 	if err != nil {
@@ -442,8 +443,9 @@ func (d *Datastore) DeleteRelationship(ctx context.Context, relationshipID uuid.
 func (d *Datastore) createTrustDomain(ctx context.Context, req *entity.TrustDomain) (*TrustDomain, error) {
 	id := uuid.New()
 	params := CreateTrustDomainParams{
-		ID:   id.String(),
-		Name: req.Name.String(),
+		ID:        id.String(),
+		Name:      req.Name.String(),
+		CreatedAt: req.CreatedAt,
 	}
 	if req.Description != "" {
 		params.Description = sql.NullString{
@@ -505,7 +507,6 @@ func (d *Datastore) createRelationship(ctx context.Context, req *entity.Relation
 		TrustDomainAConsent: string(req.TrustDomainAConsent),
 		TrustDomainBConsent: string(req.TrustDomainBConsent),
 		CreatedAt:           req.CreatedAt,
-		UpdatedAt:           req.UpdatedAt,
 	}
 
 	relationship, err := d.querier.CreateRelationship(ctx, params)
@@ -540,6 +541,7 @@ func (d *Datastore) createBundle(ctx context.Context, req *entity.Bundle) (*Bund
 		Signature:          req.Signature,
 		SigningCertificate: req.SigningCertificate,
 		TrustDomainID:      req.TrustDomainID.String(),
+		CreatedAt:          req.CreatedAt,
 	}
 
 	bundle, err := d.querier.CreateBundle(ctx, params)

--- a/pkg/server/db/sqlite/join_tokens.sql.go
+++ b/pkg/server/db/sqlite/join_tokens.sql.go
@@ -11,8 +11,8 @@ import (
 )
 
 const createJoinToken = `-- name: CreateJoinToken :one
-INSERT INTO join_tokens(id, token, expires_at, trust_domain_id)
-VALUES (?, ?, ?, ?)
+INSERT INTO join_tokens(id, token, expires_at, trust_domain_id, created_at)
+VALUES (?, ?, ?, ?, ?)
 RETURNING id, trust_domain_id, token, used, expires_at, created_at, updated_at
 `
 
@@ -21,6 +21,7 @@ type CreateJoinTokenParams struct {
 	Token         string
 	ExpiresAt     time.Time
 	TrustDomainID string
+	CreatedAt     time.Time
 }
 
 func (q *Queries) CreateJoinToken(ctx context.Context, arg CreateJoinTokenParams) (JoinToken, error) {
@@ -29,6 +30,7 @@ func (q *Queries) CreateJoinToken(ctx context.Context, arg CreateJoinTokenParams
 		arg.Token,
 		arg.ExpiresAt,
 		arg.TrustDomainID,
+		arg.CreatedAt,
 	)
 	var i JoinToken
 	err := row.Scan(

--- a/pkg/server/db/sqlite/queries/bundles.sql
+++ b/pkg/server/db/sqlite/queries/bundles.sql
@@ -1,6 +1,6 @@
 -- name: CreateBundle :one
-INSERT INTO bundles(id, data, digest, signature, signing_certificate, trust_domain_id)
-VALUES (?, ?, ?, ?, ?, ?)
+INSERT INTO bundles(id, data, digest, signature, signing_certificate, trust_domain_id, created_at)
+VALUES (?, ?, ?, ?, ?, ?, ?)
 RETURNING *;
 
 -- name: UpdateBundle :one

--- a/pkg/server/db/sqlite/queries/join_tokens.sql
+++ b/pkg/server/db/sqlite/queries/join_tokens.sql
@@ -1,6 +1,6 @@
 -- name: CreateJoinToken :one
-INSERT INTO join_tokens(id, token, expires_at, trust_domain_id)
-VALUES (?, ?, ?, ?)
+INSERT INTO join_tokens(id, token, expires_at, trust_domain_id, created_at)
+VALUES (?, ?, ?, ?, ?)
 RETURNING *;
 
 -- name: UpdateJoinToken :one

--- a/pkg/server/db/sqlite/queries/relationships.sql
+++ b/pkg/server/db/sqlite/queries/relationships.sql
@@ -1,6 +1,6 @@
 -- name: CreateRelationship :one
-INSERT INTO relationships(id, trust_domain_a_id, trust_domain_b_id, trust_domain_a_consent, trust_domain_b_consent, created_at, updated_at)
-VALUES (?, ?, ?, ?, ?, ?, ?)
+INSERT INTO relationships(id, trust_domain_a_id, trust_domain_b_id, trust_domain_a_consent, trust_domain_b_consent, created_at)
+VALUES (?, ?, ?, ?, ?, ?)
 RETURNING *;
 
 -- name: UpdateRelationship :one

--- a/pkg/server/db/sqlite/queries/trust_domains.sql
+++ b/pkg/server/db/sqlite/queries/trust_domains.sql
@@ -1,6 +1,6 @@
 -- name: CreateTrustDomain :one
-INSERT INTO trust_domains(id, name, description)
-VALUES (?, ?, ?)
+INSERT INTO trust_domains(id, name, description, created_at)
+VALUES (?, ?, ?, ?)
 RETURNING *;
 
 -- name: UpdateTrustDomain :one

--- a/pkg/server/db/sqlite/relationships.sql.go
+++ b/pkg/server/db/sqlite/relationships.sql.go
@@ -11,8 +11,8 @@ import (
 )
 
 const createRelationship = `-- name: CreateRelationship :one
-INSERT INTO relationships(id, trust_domain_a_id, trust_domain_b_id, trust_domain_a_consent, trust_domain_b_consent, created_at, updated_at)
-VALUES (?, ?, ?, ?, ?, ?, ?)
+INSERT INTO relationships(id, trust_domain_a_id, trust_domain_b_id, trust_domain_a_consent, trust_domain_b_consent, created_at)
+VALUES (?, ?, ?, ?, ?, ?)
 RETURNING id, trust_domain_a_id, trust_domain_b_id, trust_domain_a_consent, trust_domain_b_consent, created_at, updated_at
 `
 
@@ -23,7 +23,6 @@ type CreateRelationshipParams struct {
 	TrustDomainAConsent string
 	TrustDomainBConsent string
 	CreatedAt           time.Time
-	UpdatedAt           time.Time
 }
 
 func (q *Queries) CreateRelationship(ctx context.Context, arg CreateRelationshipParams) (Relationship, error) {
@@ -34,7 +33,6 @@ func (q *Queries) CreateRelationship(ctx context.Context, arg CreateRelationship
 		arg.TrustDomainAConsent,
 		arg.TrustDomainBConsent,
 		arg.CreatedAt,
-		arg.UpdatedAt,
 	)
 	var i Relationship
 	err := row.Scan(

--- a/pkg/server/db/sqlite/trust_domains.sql.go
+++ b/pkg/server/db/sqlite/trust_domains.sql.go
@@ -8,11 +8,12 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"time"
 )
 
 const createTrustDomain = `-- name: CreateTrustDomain :one
-INSERT INTO trust_domains(id, name, description)
-VALUES (?, ?, ?)
+INSERT INTO trust_domains(id, name, description, created_at)
+VALUES (?, ?, ?, ?)
 RETURNING id, name, description, created_at, updated_at
 `
 
@@ -20,10 +21,16 @@ type CreateTrustDomainParams struct {
 	ID          string
 	Name        string
 	Description sql.NullString
+	CreatedAt   time.Time
 }
 
 func (q *Queries) CreateTrustDomain(ctx context.Context, arg CreateTrustDomainParams) (TrustDomain, error) {
-	row := q.queryRow(ctx, q.createTrustDomainStmt, createTrustDomain, arg.ID, arg.Name, arg.Description)
+	row := q.queryRow(ctx, q.createTrustDomainStmt, createTrustDomain,
+		arg.ID,
+		arg.Name,
+		arg.Description,
+		arg.CreatedAt,
+	)
 	var i TrustDomain
 	err := row.Scan(
 		&i.ID,

--- a/pkg/server/db/tests/datastore_setup.go
+++ b/pkg/server/db/tests/datastore_setup.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/HewlettPackard/galadriel/pkg/server/db"
 	"github.com/HewlettPackard/galadriel/pkg/server/db/postgres"
 	"github.com/HewlettPackard/galadriel/pkg/server/db/sqlite"
 	"github.com/ory/dockertest/v3"
@@ -20,7 +21,7 @@ const (
 	dbname        = "test_db"
 )
 
-func setupSQLiteDatastore(t *testing.T) *sqlite.Datastore {
+func setupSQLiteDatastore(t *testing.T) db.Datastore {
 	// Use an in-memory database
 	dsn := ":memory:"
 
@@ -28,6 +29,7 @@ func setupSQLiteDatastore(t *testing.T) *sqlite.Datastore {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
+		t.Log("Closing SQLite database")
 		err = datastore.Close()
 		require.NoError(t, err)
 	})
@@ -35,12 +37,13 @@ func setupSQLiteDatastore(t *testing.T) *sqlite.Datastore {
 	return datastore
 }
 
-func setupPostgresDatastore(t *testing.T) *postgres.Datastore {
+func setupPostgresDatastore(t *testing.T) db.Datastore {
 	conn := startPostgresDB(t)
 	datastore, err := postgres.NewDatastore(conn)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
+		t.Log("Closing Postgres database")
 		err = datastore.Close()
 		require.NoError(t, err)
 	})

--- a/pkg/server/db/tests/datastore_test.go
+++ b/pkg/server/db/tests/datastore_test.go
@@ -19,8 +19,9 @@ var (
 	spiffeTD2 = spiffeid.RequireTrustDomainFromString("bar.test")
 	spiffeTD3 = spiffeid.RequireTrustDomainFromString("baz.test")
 
-	location, _   = time.LoadLocation("UTC")
-	inFiveSeconds = time.Now().In(location).Add(5 * time.Second)
+	location, _ = time.LoadLocation("UTC")
+	// inFiveSeconds is truncated to microsecond precision to match the database's timestamp precision.
+	inFiveSeconds = time.Now().In(location).Add(5 * time.Second).Truncate(time.Microsecond)
 
 	sqliteExpectedUniqueErr       = "UNIQUE constraint failed"
 	postgresExpectedUniqueErr     = "duplicate key value violates unique constraint"

--- a/pkg/server/db/tests/datastore_test.go
+++ b/pkg/server/db/tests/datastore_test.go
@@ -18,38 +18,39 @@ var (
 	spiffeTD1 = spiffeid.RequireTrustDomainFromString("foo.test")
 	spiffeTD2 = spiffeid.RequireTrustDomainFromString("bar.test")
 	spiffeTD3 = spiffeid.RequireTrustDomainFromString("baz.test")
+
+	location, _   = time.LoadLocation("UTC")
+	inFiveSeconds = time.Now().In(location).Add(5 * time.Second)
+
+	sqliteExpectedUniqueErr       = "UNIQUE constraint failed"
+	postgresExpectedUniqueErr     = "duplicate key value violates unique constraint"
+	sqliteExpectedForeignKeyErr   = "FOREIGN KEY constraint failed"
+	postgresExpectedForeignKeyErr = "violates foreign key constraint"
 )
 
-func TestSuite(t *testing.T) {
+func TestDatastoreOperations(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	sqliteDS := func() db.Datastore {
-		return setupSQLiteDatastore(t)
-	}
-	runTests(t, ctx, sqliteDS)
-
-	postgresDS := func() db.Datastore {
-		return setupPostgresDatastore(t)
-	}
-	runTests(t, ctx, postgresDS)
+	runDatastoreTests(t, ctx, setupSQLiteDatastore)
+	runDatastoreTests(t, ctx, setupPostgresDatastore)
 }
 
-func runTests(t *testing.T, ctx context.Context, newDS func() db.Datastore) {
+func runDatastoreTests(t *testing.T, ctx context.Context, newDS func(*testing.T) db.Datastore) {
 	t.Run("Test CRUD TrustDomains", func(t *testing.T) {
 		t.Parallel()
-		ds := newDS()
-		defer closeDatastore(t, ds)
+		ds := newDS(t)
 
 		// Create trust domain
 		req1 := &entity.TrustDomain{
-			Name: spiffeTD1,
+			Name:      spiffeTD1,
+			CreatedAt: inFiveSeconds,
 		}
 		td1, err := ds.CreateOrUpdateTrustDomain(ctx, req1)
 		assert.NoError(t, err)
 		assert.NotNil(t, td1.ID)
 		assert.Equal(t, req1.Name, td1.Name)
-		assert.NotNil(t, td1.CreatedAt)
+		assertEqualDate(t, inFiveSeconds, td1.CreatedAt.In(location))
 		assert.NotNil(t, td1.UpdatedAt)
 
 		// Create second trust domain
@@ -106,8 +107,7 @@ func runTests(t *testing.T, ctx context.Context, newDS func() db.Datastore) {
 	})
 	t.Run("Test TrustDomain Unique Constraint", func(t *testing.T) {
 		t.Parallel()
-		ds := newDS()
-		defer closeDatastore(t, ds)
+		ds := newDS(t)
 
 		td1 := &entity.TrustDomain{
 			Name: spiffeTD1,
@@ -122,14 +122,11 @@ func runTests(t *testing.T, ctx context.Context, newDS func() db.Datastore) {
 		_, err = ds.CreateOrUpdateTrustDomain(ctx, td2)
 		require.Error(t, err)
 
-		sqliteExpectedErr := "UNIQUE constraint failed"
-		postgresExpectedErr := "duplicate key value violates unique constraint"
-		assertErrorString(t, err, sqliteExpectedErr, postgresExpectedErr)
+		assertErrorString(t, err, sqliteExpectedUniqueErr, postgresExpectedUniqueErr)
 	})
 	t.Run("Test CRUD Relationships", func(t *testing.T) {
 		t.Parallel()
-		ds := newDS()
-		defer closeDatastore(t, ds)
+		ds := newDS(t)
 
 		// Create TrustDomains
 		td1 := &entity.TrustDomain{
@@ -151,12 +148,13 @@ func runTests(t *testing.T, ctx context.Context, newDS func() db.Datastore) {
 		req1 := &entity.Relationship{
 			TrustDomainAID: td1.ID.UUID,
 			TrustDomainBID: td2.ID.UUID,
+			CreatedAt:      inFiveSeconds,
 		}
 
 		relationship1, err := ds.CreateOrUpdateRelationship(ctx, req1)
 		assert.NoError(t, err)
 		assert.NotNil(t, relationship1.ID)
-		assert.NotNil(t, relationship1.CreatedAt)
+		assert.Equal(t, req1.CreatedAt, relationship1.CreatedAt.In(location))
 		assert.NotNil(t, relationship1.UpdatedAt)
 		assert.Equal(t, req1.TrustDomainAID, relationship1.TrustDomainAID)
 		assert.Equal(t, req1.TrustDomainBID, relationship1.TrustDomainBID)
@@ -228,26 +226,23 @@ func runTests(t *testing.T, ctx context.Context, newDS func() db.Datastore) {
 	})
 	t.Run("Test Relationship ForeignKey Constraints", func(t *testing.T) {
 		t.Parallel()
-		ds := newDS()
-		defer closeDatastore(t, ds)
+		ds := newDS(t)
 
 		td1 := &entity.TrustDomain{
 			Name: spiffeTD1,
 		}
-		td1, err := ds.CreateOrUpdateTrustDomain(ctx, td1)
-		assert.NoError(t, err)
+		td1 = createTrustDomain(ctx, t, ds, td1)
 
 		td2 := &entity.TrustDomain{
 			Name: spiffeTD2,
 		}
-		td2, err = ds.CreateOrUpdateTrustDomain(ctx, td2)
-		assert.NoError(t, err)
+		td2 = createTrustDomain(ctx, t, ds, td2)
 
 		relationship1 := &entity.Relationship{
 			TrustDomainAID: td1.ID.UUID,
 			TrustDomainBID: td2.ID.UUID,
 		}
-		relationship1, err = ds.CreateOrUpdateRelationship(ctx, relationship1)
+		relationship1, err := ds.CreateOrUpdateRelationship(ctx, relationship1)
 		assert.NoError(t, err)
 
 		// Cannot add a new relationship for the same TrustDomains
@@ -255,42 +250,33 @@ func runTests(t *testing.T, ctx context.Context, newDS func() db.Datastore) {
 		_, err = ds.CreateOrUpdateRelationship(ctx, relationship1)
 		require.Error(t, err)
 
-		sqliteExpectedError := "UNIQUE constraint failed"
-		postgresExpectedError := "duplicate key value violates unique constraint"
-		assertErrorString(t, err, sqliteExpectedError, postgresExpectedError)
+		assertErrorString(t, err, sqliteExpectedUniqueErr, postgresExpectedUniqueErr)
 
 		// Cannot delete Trust Domain that has a relationship associated
 		err = ds.DeleteTrustDomain(ctx, td1.ID.UUID)
 		require.Error(t, err)
 
-		sqliteExpectedError = "FOREIGN KEY constraint failed"
-		postgresExpectedError = "violates foreign key constraint"
-		assertErrorString(t, err, sqliteExpectedError, postgresExpectedError)
+		assertErrorString(t, err, sqliteExpectedForeignKeyErr, postgresExpectedForeignKeyErr)
 
 		// Cannot delete Trust Domain that has a relationship associated
 		err = ds.DeleteTrustDomain(ctx, td2.ID.UUID)
 		require.Error(t, err)
-		assertErrorString(t, err, sqliteExpectedError, postgresExpectedError)
+		assertErrorString(t, err, sqliteExpectedForeignKeyErr, postgresExpectedForeignKeyErr)
 	})
 	t.Run("Test CRUD Bundles", func(t *testing.T) {
 		t.Parallel()
-		ds := newDS()
-		defer closeDatastore(t, ds)
+		ds := newDS(t)
 
 		// Create trustDomains to associate the bundles
 		td1 := &entity.TrustDomain{
 			Name: spiffeTD1,
 		}
-		td1, err := ds.CreateOrUpdateTrustDomain(ctx, td1)
-		assert.NoError(t, err)
-		assert.NotNil(t, td1.ID)
+		td1 = createTrustDomain(ctx, t, ds, td1)
 
 		td2 := &entity.TrustDomain{
 			Name: spiffeTD2,
 		}
-		td2, err = ds.CreateOrUpdateTrustDomain(ctx, td2)
-		assert.NoError(t, err)
-		assert.NotNil(t, td2.ID)
+		td2 = createTrustDomain(ctx, t, ds, td2)
 
 		// Create first Data - trustDomain-1
 		req1 := &entity.Bundle{
@@ -299,6 +285,7 @@ func runTests(t *testing.T, ctx context.Context, newDS func() db.Datastore) {
 			Signature:          []byte{4, 2},
 			SigningCertificate: []byte{50, 60},
 			TrustDomainID:      td1.ID.UUID,
+			CreatedAt:          inFiveSeconds,
 		}
 
 		b1, err := ds.CreateOrUpdateBundle(ctx, req1)
@@ -309,6 +296,7 @@ func runTests(t *testing.T, ctx context.Context, newDS func() db.Datastore) {
 		assert.Equal(t, req1.Signature, b1.Signature)
 		assert.Equal(t, req1.SigningCertificate, b1.SigningCertificate)
 		assert.Equal(t, req1.TrustDomainID, b1.TrustDomainID)
+		assert.Equal(t, req1.CreatedAt, b1.CreatedAt.In(location))
 
 		// Look up bundle stored in DB and compare
 		stored, err := ds.FindBundleByID(ctx, b1.ID.UUID)
@@ -394,16 +382,13 @@ func runTests(t *testing.T, ctx context.Context, newDS func() db.Datastore) {
 	})
 	t.Run("Test Bundle Unique TrustDomain Constraint", func(t *testing.T) {
 		t.Parallel()
-		ds := newDS()
-		defer closeDatastore(t, ds)
+		ds := newDS(t)
 
 		// Create trustDomain to associate the bundles
 		td1 := &entity.TrustDomain{
 			Name: spiffeTD1,
 		}
-		td1, err := ds.CreateOrUpdateTrustDomain(ctx, td1)
-		assert.NoError(t, err)
-		assert.NotNil(t, td1.ID)
+		td1 = createTrustDomain(ctx, t, ds, td1)
 
 		// Create Data
 		b1 := &entity.Bundle{
@@ -413,7 +398,7 @@ func runTests(t *testing.T, ctx context.Context, newDS func() db.Datastore) {
 			SigningCertificate: []byte{50, 60},
 			TrustDomainID:      td1.ID.UUID,
 		}
-		b1, err = ds.CreateOrUpdateBundle(ctx, b1)
+		b1, err := ds.CreateOrUpdateBundle(ctx, b1)
 		assert.NoError(t, err)
 		assert.NotNil(t, b1)
 
@@ -429,45 +414,38 @@ func runTests(t *testing.T, ctx context.Context, newDS func() db.Datastore) {
 		require.Error(t, err)
 		require.Nil(t, b2)
 
-		sqliteExpectedErr := "UNIQUE constraint failed"
-		postgresExpectedErr := "duplicate key value violates unique constraint"
-		assertErrorString(t, err, sqliteExpectedErr, postgresExpectedErr)
+		assertErrorString(t, err, sqliteExpectedUniqueErr, postgresExpectedUniqueErr)
 	})
 	t.Run("Test CRUD Join Tokens", func(t *testing.T) {
 		t.Parallel()
-		ds := newDS()
-		defer closeDatastore(t, ds)
+		ds := newDS(t)
 
 		// Create trustDomains to associate the join tokens
 		td1 := &entity.TrustDomain{
 			Name: spiffeTD1,
 		}
-		td1, err := ds.CreateOrUpdateTrustDomain(ctx, td1)
-		assert.NoError(t, err)
-		assert.NotNil(t, td1.ID)
+		td1 = createTrustDomain(ctx, t, ds, td1)
 
 		td2 := &entity.TrustDomain{
 			Name: spiffeTD2,
 		}
-		td2, err = ds.CreateOrUpdateTrustDomain(ctx, td2)
-		assert.NoError(t, err)
-		assert.NotNil(t, td2.ID)
+		td2 = createTrustDomain(ctx, t, ds, td2)
 
-		loc, _ := time.LoadLocation("UTC")
-		expiry := time.Now().In(loc).Add(1 * time.Hour)
+		expiry := time.Now().In(location).Add(1 * time.Hour)
 
 		// Create first join_token -> trustDomain_1
 		req1 := &entity.JoinToken{
 			Token:         uuid.NewString(),
 			ExpiresAt:     expiry,
 			TrustDomainID: td1.ID.UUID,
+			CreatedAt:     inFiveSeconds,
 		}
 
 		token1, err := ds.CreateJoinToken(ctx, req1)
 		assert.NoError(t, err)
 		assert.NotNil(t, token1)
 		assert.Equal(t, req1.Token, token1.Token)
-		assertEqualDate(t, req1.ExpiresAt, token1.ExpiresAt.In(loc))
+		assertEqualDate(t, req1.ExpiresAt, token1.ExpiresAt.In(location))
 		require.False(t, token1.Used)
 		assert.Equal(t, req1.TrustDomainID, token1.TrustDomainID)
 
@@ -490,7 +468,7 @@ func runTests(t *testing.T, ctx context.Context, newDS func() db.Datastore) {
 		assert.Equal(t, req1.TrustDomainID, token1.TrustDomainID)
 		require.False(t, token2.Used)
 
-		assertEqualDate(t, req2.ExpiresAt, token2.ExpiresAt.In(loc))
+		assertEqualDate(t, req2.ExpiresAt, token2.ExpiresAt.In(location))
 		assert.Equal(t, req2.TrustDomainID, token2.TrustDomainID)
 
 		// Look up token stored in DB and compare
@@ -581,29 +559,23 @@ func runTests(t *testing.T, ctx context.Context, newDS func() db.Datastore) {
 func createTrustDomain(ctx context.Context, t *testing.T, ds db.Datastore, req *entity.TrustDomain) *entity.TrustDomain {
 	td1, err := ds.CreateOrUpdateTrustDomain(ctx, req)
 	require.NoError(t, err)
+	require.NotNil(t, td1)
+	require.NotNil(t, td1.ID)
 	return td1
 }
 
-func closeDatastore(t *testing.T, ds db.Datastore) {
-	switch d := ds.(type) {
-	case interface {
-		Close() error
-	}:
-		if err := d.Close(); err != nil {
-			t.Errorf("error closing datastore: %v", err)
-		}
-	}
-}
-
 // assertErrorString asserts that the error string is one of the expected error strings
-func assertErrorString(t *testing.T, err error, s1, s2 string) {
+func assertErrorString(t *testing.T, err error, expectedErrors ...string) {
 	if err == nil {
-		t.Fatalf("expected error containing either '%s' or '%s', but got no error", s1, s2)
+		t.Errorf("expected error containing one of '%s', but got no error", strings.Join(expectedErrors, "' or '"))
 	}
 	errMsg := err.Error()
-	if !strings.Contains(errMsg, s1) && !strings.Contains(errMsg, s2) {
-		t.Fatalf("expected error containing either '%s' or '%s', but got '%s'", s1, s2, errMsg)
+	for _, expectedError := range expectedErrors {
+		if strings.Contains(errMsg, expectedError) {
+			return
+		}
 	}
+	t.Errorf("expected error containing one of '%s', but got '%s'", strings.Join(expectedErrors, "' or '"), errMsg)
 }
 
 func assertEqualDate(t *testing.T, time1 time.Time, time2 time.Time) {


### PR DESCRIPTION
<!--
1. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull request check list**

- [X] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**

Allowing the customer to optionally set the `created_at` field while using `now()` as the default value when not provided, providing flexibility for specific use cases where the customer wants to control the creation timestamp. This can be also useful for testing. 

On the other hand, the Datastore layer continues not allowing the customer to set the `updated_at` field which aligns with the typical practice of using the current timestamp as the indicator of when a record was last modified. This ensures the integrity of the auditing process, as it prevents tampering with the timestamp for auditing purposes.


**Description of change**

Enabled setting the `created_at` field when inserting a new entity (`TrustDomain`, `Relationship`, `JoinToken`, `Bundle`).

Improved the Datastore tests to enhance consistency, streamline Datastore instance cleanup, and make various minor improvements.

**Which issue this pull requests fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this pull request is merged -->

