### PR TITLE
Improve `X509CA` disk implementation

### DIFF
--- a/cmd/server/cli/config_test.go
+++ b/cmd/server/cli/config_test.go
@@ -29,7 +29,7 @@ providers {
 	X509CA "disk" {
 		key_file_path = "./intermediate-ca.key"
 		cert_file_path = "./intermediate-ca.crt"
-        bundle_file_path = "./bundle.crt"
+		bundle_file_path = "./bundle.crt"
 	}
 
     KeyManager "memory" {}

--- a/cmd/server/cli/config_test.go
+++ b/cmd/server/cli/config_test.go
@@ -27,8 +27,9 @@ providers {
     }
 
 	X509CA "disk" {
-		key_file_path = "./root_ca.key"
-		cert_file_path = "./root_ca.crt"
+		key_file_path = "./intermediate-ca.key"
+		cert_file_path = "./intermediate-ca.crt"
+        bundle_file_path = "./bundle.crt"
 	}
 
     KeyManager "memory" {}

--- a/conf/server/server_full.conf
+++ b/conf/server/server_full.conf
@@ -28,12 +28,23 @@ providers {
     #   connection_string = "postgresql://postgres:postgres@localhost:5432/galadriel"
     #}
 
-    # X509CA "disk": Uses a ROOT CA loaded from disk to issue X509 certificates.
+    # X509CA "disk": Utilizes a Certificate Authority (CA) certificate, loaded from disk, to issue X509 certificates.
     X509CA "disk" {
-        # Path to the root CA private key file. PEM format.
+        # key_file_path: The path to the PEM-encoded private key file of the CA.
+        # This path can be relative or absolute.
         key_file_path = "./conf/server/dummy_root_ca.key"
-        # Path to the root CA certificate file. PEM format.
+
+        # cert_file_path: The path to the PEM-encoded certificate file of the CA.
+        # This path can be relative or absolute.
         cert_file_path = "./conf/server/dummy_root_ca.crt"
+
+        # bundle_file_path: Optional. Specifies the path to a file with one or more PEM-encoded certificates
+        # forming an upstream chain of trust. If Galadriel is using a self-signed CA, this can be omitted.
+        # "However, if Galadriel uses an intermediate CA from a chain of trust that leads back to an external root CA
+        # to issue certificates, this parameter should point to a file containing one or more certificates that form
+        # this chain of trust. The path can be relative or absolute.
+        # Note: This bundle does not need to include the root CA itself.
+        # bundle_file_path = ""
     }
 
     # KeyManager "memory": A key manager for generating keys and signing certificates that stores keys in memory.

--- a/conf/server/server_full.conf
+++ b/conf/server/server_full.conf
@@ -40,7 +40,7 @@ providers {
 
         # bundle_file_path: Optional. Specifies the path to a file with one or more PEM-encoded certificates
         # forming an upstream chain of trust. If Galadriel is using a self-signed CA, this can be omitted.
-        # "However, if Galadriel uses an intermediate CA from a chain of trust that leads back to an external root CA
+        # However, if Galadriel uses an intermediate CA from a chain of trust that leads back to an external root CA
         # to issue certificates, this parameter should point to a file containing one or more certificates that form
         # this chain of trust. The path can be relative or absolute.
         # Note: This bundle does not need to include the root CA itself.

--- a/doc/galadriel_server.md
+++ b/doc/galadriel_server.md
@@ -70,9 +70,12 @@ providers {
 
 The X509CA section provides configuration details for X.509 CA providers:
 
-| Option | Description                                                                                                                                                                                                                                 |
-|--------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `disk` | Uses a ROOT CA and private key loaded from disk to issue X.509 certificates. The `key_file_path` is the path to the root CA private key file in PEM format. The `cert_file_path` is the path to the root CA certificate file in PEM format. |
+| Option             | Description                                                                                                                                                                                                                                                                                                                        |
+|--------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `disk`             | Uses a CA (either ROOT or INTERMEDIATE) and private key loaded from disk to issue X.509 certificates.                                                                                                                                                                                                                              |
+| `key_file_path`    | Path to the CA private key file in PEM format. This path can be relative or absolute.                                                                                                                                                                                                                                              |
+| `cert_file_path`   | Path to the CA certificate file in PEM format. This path can be relative or absolute.                                                                                                                                                                                                                                              |
+| `bundle_file_path` | Required when the cert_file_path does not contain a self-signed CA certificate. This is the path to the file containing one or more certificates forming the chain of trust to a root CA. This file should contain any number of intermediate CA certificates that chain back to a root CA. This path can be relative or absolute. |
 
 #### Example:
 
@@ -81,9 +84,13 @@ providers {
   X509CA "disk" {
     key_file_path = "./conf/server/dummy_root_ca.key"
     cert_file_path = "./conf/server/dummy_root_ca.crt"
+    bundle_file_path = "./conf/server/root_ca.crt"
   }
 }
 ```
+
+In the example above, the bundle_file_path is set, indicating that the certificate used in cert_file_path isn't
+self-signed and requires a chain of trust to a root CA.
 
 #### KeyManager Configuration
 

--- a/pkg/common/cryptoutil/certs.go
+++ b/pkg/common/cryptoutil/certs.go
@@ -1,6 +1,7 @@
 package cryptoutil
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
@@ -29,6 +30,23 @@ var (
 	maxBigInt64 = getMaxBigInt64()
 	one         = big.NewInt(1)
 )
+
+// IsSelfSigned checks if the given certificate is self-signed.
+// In the context of a certificate hierarchy, a self-signed certificate is typically a root CA.
+func IsSelfSigned(cert *x509.Certificate) bool {
+	if err := cert.CheckSignatureFrom(cert); err != nil {
+		return false
+	}
+	return true
+}
+
+// CertificatesMatch compares two certificates to determine if they are identical.
+// The comparison is made by looking at the raw, DER-encoded form of the certificates.
+// If the raw forms of the certificates are identical, the function returns true;
+// otherwise, it returns false.
+func CertificatesMatch(cert1, cert2 *x509.Certificate) bool {
+	return bytes.Equal(cert1.Raw, cert2.Raw)
+}
 
 // LoadCertificate loads a x509.Certificate from the given path.
 func LoadCertificate(path string) (*x509.Certificate, error) {

--- a/pkg/common/cryptoutil/certs.go
+++ b/pkg/common/cryptoutil/certs.go
@@ -107,6 +107,16 @@ func EncodeCertificate(cert *x509.Certificate) []byte {
 	return pem.EncodeToMemory(&pem.Block{Type: certType, Bytes: cert.Raw})
 }
 
+// EncodeCertificates encodes the given chain of x509.Certificate into PEM format.
+func EncodeCertificates(certChain []*x509.Certificate) ([]byte, error) {
+	var certPEM []byte
+	for _, cert := range certChain {
+		certPEM = append(certPEM, EncodeCertificate(cert)...)
+		certPEM = append(certPEM, '\n')
+	}
+	return certPEM, nil
+}
+
 // CreateX509Template creates a new x509.Certificate template for a leaf certificate.
 func CreateX509Template(clk clock.Clock, publicKey crypto.PublicKey, subject pkix.Name, uris []*url.URL, dnsNames []string, ttl time.Duration) (*x509.Certificate, error) {
 	now := clk.Now()

--- a/pkg/common/cryptoutil/certs_test.go
+++ b/pkg/common/cryptoutil/certs_test.go
@@ -14,6 +14,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestIsSelfSigned(t *testing.T) {
+	cert, _ := createRootCA(t)
+	assert.True(t, IsSelfSigned(cert))
+
+	cert, _ = createCert(t, DefaultKeyType)
+	assert.False(t, IsSelfSigned(cert))
+}
+
+func TestCertificatesMatch(t *testing.T) {
+	cert, _ := createRootCA(t)
+	assert.True(t, CertificatesMatch(cert, cert))
+
+	cert2, _ := createCert(t, DefaultKeyType)
+	assert.False(t, CertificatesMatch(cert, cert2))
+}
+
 func TestLoadCertificate(t *testing.T) {
 	// not a certificate
 	_, err := LoadCertificate(rsaKeyPath)
@@ -128,7 +144,7 @@ func TestSignX509(t *testing.T) {
 	require.NotNil(t, tmpl)
 
 	// create parent certificate for signing
-	parentCert, signingKey := makeRootCA(t)
+	parentCert, signingKey := createRootCA(t)
 
 	cert, err := SignX509(tmpl, parentCert, signingKey)
 	require.NoError(t, err)
@@ -155,7 +171,7 @@ func TestSelfSignX509(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func makeRootCA(t *testing.T) (*x509.Certificate, crypto.PrivateKey) {
+func createRootCA(t *testing.T) (*x509.Certificate, crypto.PrivateKey) {
 	clk := clock.NewFake()
 	name := pkix.Name{CommonName: "root-ca"}
 	tmpl, err := CreateRootCATemplate(clk, name, 5*time.Minute)
@@ -180,7 +196,7 @@ func createCert(t *testing.T, keyType KeyType) (*x509.Certificate, crypto.Privat
 	require.NotNil(t, tmpl)
 
 	// create parent certificate for signing
-	parentCert, signingKey := makeRootCA(t)
+	parentCert, signingKey := createRootCA(t)
 
 	cert, err := SignX509(tmpl, parentCert, signingKey)
 	require.NoError(t, err)

--- a/pkg/common/x509ca/disk/disk.go
+++ b/pkg/common/x509ca/disk/disk.go
@@ -14,25 +14,39 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	ErrCertPathRequired  = "certificate file path is required"
+	ErrPrivateKeyPathReq = "private key file path is required"
+	ErrPublicKeyRequired = "public key is required"
+	ErrTTLRequired       = "TTL is required"
+	ErrTrustBundleReq    = "certificate is not self-signed. A trust bundle is required"
+)
+
 // X509CA is a CA that signs X509 certificates using a disk-based private key and ROOT CA certificate.
 type X509CA struct {
-	// Interface for an opaque private key that can be used for signing operations.
+	// signer is an interface for an opaque private key that can be used for signing operations.
 	signer crypto.Signer
 
-	// ROOT CA certificate for signing X509 certificates.
+	// certificate is the CA certificate for signing X509 certificates.
 	certificate *x509.Certificate
 
-	clock clock.Clock
+	// trustBundle is a collection of trusted certificates.
+	trustBundle []*x509.Certificate
 
+	clock  clock.Clock
 	logger logrus.FieldLogger
 }
 
 // Config is the configuration for a disk-based X509CA.
 type Config struct {
-	// The path to the file containing the X.509 ROOT CA certificate.
+	// The path to the file containing the X.509 CA certificate.
 	CertFilePath string `hcl:"cert_file_path"`
-	// The path to the file containing the X.509 ROOT CA private key.
+	// The path to the file containing the X.509 CA private key.
 	KeyFilePath string `hcl:"key_file_path"`
+	// The path to the file containing the X.509 trust bundle.
+	BundleFilePath string `hcl:"bundle_file_path"`
+
+	Clock clock.Clock
 }
 
 // New creates a new disk-based X509CA.
@@ -40,19 +54,27 @@ type Config struct {
 // Call Configure() to configure it passing the HCL configuration.
 func New() (*X509CA, error) {
 	return &X509CA{
-		clock:  clock.New(),
 		logger: logrus.WithField(telemetry.SubsystemName, telemetry.DiskX509CA),
 	}, nil
 }
 
 // Configure configures the disk-based X509CA from the given map.
 func (ca *X509CA) Configure(config *Config) error {
+	if config == nil {
+		return errors.New("configuration is required")
+	}
+
+	if config.Clock == nil {
+		config.Clock = clock.New()
+	}
+	ca.clock = config.Clock
+
 	if config.CertFilePath == "" {
-		return errors.New("certificate file path is required")
+		return errors.New(ErrCertPathRequired)
 	}
 
 	if config.KeyFilePath == "" {
-		return errors.New("private key file path is required")
+		return errors.New(ErrPrivateKeyPathReq)
 	}
 
 	key, err := cryptoutil.LoadPrivateKey(config.KeyFilePath)
@@ -65,14 +87,12 @@ func (ca *X509CA) Configure(config *Config) error {
 		return fmt.Errorf("unable to load certificate: %v", err)
 	}
 
-	// verify the certificate is self-signed (i.e. ROOT CA)
-	if err := cert.CheckSignatureFrom(cert); err != nil {
-		return fmt.Errorf("certificate is not self-signed")
-	}
-
-	// verify the certificate public key matches the private key
 	if err := cryptoutil.VerifyCertificatePrivateKey(cert, key); err != nil {
 		return fmt.Errorf("certificate verification failed: %w", err)
+	}
+
+	if err := ca.processTrustBundle(config, cert); err != nil {
+		return err
 	}
 
 	ca.certificate = cert
@@ -85,10 +105,10 @@ func (ca *X509CA) Configure(config *Config) error {
 // is bound to the given public key and subject.
 func (ca *X509CA) IssueX509Certificate(ctx context.Context, params *x509ca.X509CertificateParams) ([]*x509.Certificate, error) {
 	if params.PublicKey == nil {
-		return nil, errors.New("public key is required")
+		return nil, errors.New(ErrPublicKeyRequired)
 	}
 	if params.TTL == 0 {
-		return nil, errors.New("TTL is required")
+		return nil, errors.New(ErrTTLRequired)
 	}
 
 	template, err := cryptoutil.CreateX509Template(ca.clock, params.PublicKey, params.Subject, params.URIs, params.DNSNames, params.TTL)
@@ -101,5 +121,85 @@ func (ca *X509CA) IssueX509Certificate(ctx context.Context, params *x509ca.X509C
 		return nil, fmt.Errorf("failed to sign X509 certificate: %w", err)
 	}
 
-	return []*x509.Certificate{cert}, nil
+	chain, err := ca.buildCertificateChain(cert)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build certificate chain: %w", err)
+	}
+
+	return chain, nil
+}
+
+func (ca *X509CA) buildCertificateChain(cert *x509.Certificate) ([]*x509.Certificate, error) {
+	chain := []*x509.Certificate{cert}
+
+	// If the CA has a trust bundle, append the intermediate and the certificates in the trust bundle to the chain
+	if len(ca.trustBundle) > 0 {
+		chain = append(chain, ca.certificate)
+		chain = append(chain, ca.trustBundle...)
+	}
+
+	return chain, nil
+}
+
+func (ca *X509CA) processTrustBundle(config *Config, cert *x509.Certificate) error {
+	if config.BundleFilePath == "" {
+		return ca.verifySelfSigned(cert)
+	}
+
+	return ca.loadAndVerifyTrustBundle(config, cert)
+}
+
+func (ca *X509CA) loadAndVerifyTrustBundle(config *Config, cert *x509.Certificate) error {
+	bundle, err := ca.loadTrustBundle(config)
+	if err != nil {
+		return err
+	}
+
+	return ca.verifyTrustBundle(cert, bundle)
+}
+
+func (ca *X509CA) loadTrustBundle(config *Config) ([]*x509.Certificate, error) {
+	bundle, err := cryptoutil.LoadCertificates(config.BundleFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load trust bundle: %v", err)
+	}
+
+	return bundle, nil
+}
+
+func (ca *X509CA) verifyTrustBundle(cert *x509.Certificate, bundle []*x509.Certificate) error {
+	if err := ca.verifyCertificateCanChainToTrustBundle(cert, bundle); err != nil {
+		return fmt.Errorf("certificate chain verification failed: %w", err)
+	}
+
+	ca.trustBundle = bundle
+	return nil
+}
+
+func (ca *X509CA) verifySelfSigned(cert *x509.Certificate) error {
+	if err := cert.CheckSignatureFrom(cert); err != nil {
+		return errors.New(ErrTrustBundleReq)
+	}
+	return nil
+}
+
+func (ca *X509CA) verifyCertificateCanChainToTrustBundle(cert *x509.Certificate, intermediates []*x509.Certificate) error {
+	intermediatePool := x509.NewCertPool()
+	rootPool := x509.NewCertPool()
+	for _, intermediate := range intermediates {
+		intermediatePool.AddCert(intermediate)
+		rootPool.AddCert(intermediate)
+	}
+
+	opts := x509.VerifyOptions{
+		Roots:         rootPool,
+		Intermediates: intermediatePool,
+		CurrentTime:   ca.clock.Now(),
+	}
+
+	if _, err := cert.Verify(opts); err != nil {
+		return fmt.Errorf("unable to chain the certificate to a trusted CA: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/server/catalog/catalog_test.go
+++ b/pkg/server/catalog/catalog_test.go
@@ -22,6 +22,7 @@ providers {
 	X509CA "disk" {
 		key_file_path = "%s"
 		cert_file_path = "%s"
+        bundle_file_path = "%s"
 	}
     KeyManager "memory" {}
 }
@@ -54,7 +55,7 @@ func TestLoadFromProvidersConfig(t *testing.T) {
 	tempDir, cleanup := setupTest(t)
 	defer cleanup()
 
-	hclConfig := fmt.Sprintf(hclConfigTemplate, ":memory:", tempDir+"/root-ca.key", tempDir+"/root-ca.crt")
+	hclConfig := fmt.Sprintf(hclConfigTemplate, ":memory:", tempDir+"/intermediate-ca.key", tempDir+"/intermediate-ca.crt", tempDir+"/root-ca.crt")
 
 	hclBody, diagErr := hclsyntax.ParseConfig([]byte(hclConfig), "", hcl.Pos{Line: 1, Column: 1})
 	require.False(t, diagErr.HasErrors())
@@ -68,6 +69,7 @@ func TestLoadFromProvidersConfig(t *testing.T) {
 	require.NotNil(t, pc)
 
 	cat := New()
+	cat.clk = clk
 	err = cat.LoadFromProvidersConfig(pc)
 	require.NoError(t, err)
 	require.NotNil(t, cat.GetDatastore())

--- a/test/certtest/certs.go
+++ b/test/certtest/certs.go
@@ -107,5 +107,10 @@ func CreateTestCACertificates(t *testing.T, clk clock.Clock) string {
 	err = os.WriteFile(tempDir+"/other-ca.key", cryptoutil.EncodeRSAPrivateKey(rsaKey), keyPerm)
 	require.NoError(t, err)
 
+	// create a bundle of all the CA certificates
+	bundlePEM, err := cryptoutil.EncodeCertificates([]*x509.Certificate{rootCA, intermediateCA, intermediateCA2, otherCA})
+	require.NoError(t, err)
+	err = os.WriteFile(tempDir+"/bundle.crt", bundlePEM, crtPerm)
+
 	return tempDir
 }

--- a/test/certtest/certs.go
+++ b/test/certtest/certs.go
@@ -111,6 +111,7 @@ func CreateTestCACertificates(t *testing.T, clk clock.Clock) string {
 	bundlePEM, err := cryptoutil.EncodeCertificates([]*x509.Certificate{rootCA, intermediateCA, intermediateCA2, otherCA})
 	require.NoError(t, err)
 	err = os.WriteFile(tempDir+"/bundle.crt", bundlePEM, crtPerm)
+	require.NoError(t, err)
 
 	return tempDir
 }


### PR DESCRIPTION
<!--
1. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull request check list**

- [X] Proper tests/regressions included?
- [X] Documentation updated?

**Description of change**

This pull request enhances the X509CA "disk" implementation by introducing a new configuration option called `bundle_file_path` and enabling the use of intermediate CA certificates. The `bundle_file_path` parameter is now required when the specified `cert_file_path` does not contain a self-signed (root) CA. It allows Galadriel to issue certificates based on an external chain of trust. The bundle file should contain one or more intermediate CA certificates and/or root CA certificates, forming the trust chain up to the root CA. This update ensures more flexibility in managing CA certificates and provides better support for complex trust relationships.

This PR also updates the Galadriel server to utilize the entire certificate chain issued by the X509CA as the TLS certificate for the TLS connections with the Harvesters.

In summary, the changes include:

X509CA "disk" Implementation:
- Added a new configuration option `bundle_file_path` to support external chains of trust.
- Updated the X509CA documentation to reflect the new configuration option.
- Modified the X509CA test cases to cover the new functionality.

Galadriel Server:
- Updated the server code to utilize the entire certificate chain issued by the X509CA as the TLS certificate for the TLS connections with the Harvesters.

These changes provide a more robust and flexible X509CA "disk" implementation, enabling Galadriel to handle a broader range of trust scenarios. 

**Which issue this pull requests fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this pull request is merged -->

